### PR TITLE
Add PHP 7.4

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -28,6 +28,19 @@ extra_tags=("$@")
 # in the function call.
 declare -a tags
 
+# Usage: should-push
+#
+# This function determines if the built images should be pushed up to the Docker Hub.
+# There are a few conditions:
+#   1. This must not be a local build,
+#   2. This must not be triggered by a pull request, and
+#   3. The branch being built must be master.
+should-push() {
+  test "$BUILDKITE_PIPELINE_PROVIDER" != local &&
+    test "$BUILDKITE_PULL_REQUEST" == false &&
+    test "$BUILDKITE_BRANCH" == master
+}
+
 # Usage:
 #
 #   # Set up the tags array variable before calling
@@ -78,7 +91,7 @@ done
 
 build xdebug PHP_VERSION="$version" XDEBUG_VERSION="$XDEBUG_VERSION"
 
-if test "$BUILDKITE_BRANCH" == master && test "$BUILDKITE_PULL_REQUEST" == false; then
+if should-push; then
   echo "--- Push"
   docker push "$repository"
 fi

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -43,6 +43,11 @@ create-step() {
       XDEBUG_VERSION: "$xdebug"
     commands:
       - bash .buildkite/build.sh $version $minor ${php_versions[$version]}
+YAML
+
+  # Use authentication plugins if we're building somewhere other than on a local machine
+  if test "${BUILDKITE_PROJECT_PROVIDER:-local}" != local; then
+    cat <<YAML
     plugins:
       - seek-oss/aws-sm#v2.0.0:
           env:
@@ -51,13 +56,12 @@ create-step() {
           username: f1builder
           password-env: DOCKER_LOGIN_PASSWORD
 YAML
+  fi
 }
 
 # For each key (i.e., PHP version), we output a Buildkite pipeline step and upload it
 # via the agent.
-{
-  echo "steps:"
-  for version in "${!php_versions[@]}"; do
-    create-step "$version"
-  done
-} | buildkite-agent pipeline upload
+echo "steps:"
+for version in "${!php_versions[@]}"; do
+  create-step "$version"
+done

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -14,7 +14,8 @@ declare -A php_versions=(
   [7.0.33]=""
   [7.1.33]=""
   [7.2.25]=""
-  [7.3.12]="7 latest"
+  [7.3.12]=""
+  [7.4.0]="7 latest"
 )
 
 # XDebug sometimes drops support for EOL'ed PHP versions, so we can't use the stable

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,4 @@
+steps:
+  - label: ":pipeline:"
+    commands:
+      - bash .buildkite/pipeline.sh | buildkite-agent pipeline upload


### PR DESCRIPTION
This PR makes two changes:

1. It makes the pipeline runnable under the Buildkite CLI, and
2. It adds PHP 7.4 to the matrix of built images.