### PR TITLE
Concurrency

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -43,7 +43,7 @@ create-step() {
   - label: ":docker: :php: v$minor"
     env:
       XDEBUG_VERSION: "$xdebug"
-    concurrency: 3
+    concurrency: 5
     concurrency_group: "f1/docker"
     commands:
       - bash .buildkite/build.sh $version $minor ${php_versions[$version]}

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -43,6 +43,8 @@ create-step() {
   - label: ":docker: :php: v$minor"
     env:
       XDEBUG_VERSION: "$xdebug"
+    concurrency: 3
+    concurrency_group: "f1/docker"
     commands:
       - bash .buildkite/build.sh $version $minor ${php_versions[$version]}
 YAML


### PR DESCRIPTION
This PR creates a concurrency group called `f1/docker` to limit all Docker-related builds to 5 agents maximum. This should avoid constraining other build resources when we perform version bumps.