### PR TITLE
Lower opcache revalidate frequency for dev images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN f1-ext-install pecl:xdebug@${XDEBUG_VERSION}
 
 # Since this is a development-oriented image, we can reduce the parameters for
 # less-optimal behavior. This prevents issues where a file appears to be "stuck" in an old
-# version until opcache finally re-scans the update file.
+# version until opcache finally re-scans the updated file.
 #
 # We lower the revalidate frequency to 5 seconds - enough to cache files for a reload or
 # two, but not too long so as to stymie rapid iteration.

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,14 @@ FROM base AS xdebug
 
 ARG XDEBUG_VERSION
 RUN f1-ext-install pecl:xdebug@${XDEBUG_VERSION}
+
+# Since this is a development-oriented image, we can reduce the parameters for
+# less-optimal behavior. This prevents issues where a file appears to be "stuck" in an old
+# version until opcache finally re-scans the update file.
+#
+# We lower the revalidate frequency to 5 seconds - enough to cache files for a reload or
+# two, but not too long so as to stymie rapid iteration.
+
+RUN sed -i \
+  -e 's/revalidate_freq=60/revalidate_freq=5/' \
+  /usr/local/etc/php/conf.d/opcache-recommended.ini


### PR DESCRIPTION
This PR reduces the revalidate frequency for opcache when using the `xdebug` variant. The value of 5 seconds was chosen arbitrarily, but should at least be enough to keep code in cache for a page load or two before it expires again.

Should anyone wish to change this, the updated Dockerfile should at least serve as a useful reference for how to update a file in-place during a Docker build.